### PR TITLE
Fix un-openable xcworkspace

### DIFF
--- a/templates/ios.js
+++ b/templates/ios.js
@@ -57,8 +57,7 @@ RCT_EXPORT_MODULE()
   `,
 }, {
   name: ({ name }) => `${platform}/${name}.xcworkspace/contents.xcworkspacedata`,
-  content: ({ name }) => `// !$*UTF8*$!
-<?xml version="1.0" encoding="UTF-8"?>
+  content: ({ name }) => `<?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
    <FileRef


### PR DESCRIPTION
I get an error: The document “ProjectName.xcworkspace” could not be opened. Removing this fixes it so that I can open the workspace.